### PR TITLE
Backfill missing lab metadata (17 files)

### DIFF
--- a/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
+++ b/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
@@ -5,6 +5,9 @@ lab:
   duration: 25 minutes
   level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Create class definitions and instantiate objects

--- a/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
+++ b/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
@@ -3,7 +3,7 @@ lab:
   title: Exercise - Create class definitions and instantiate objects
   description: Learn how to create class definitions that include fields and constructors, and how to use the "new" operator to instantiate objects that expose encapsulated field data.
   duration: 25 minutes
-  level: 100
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
+++ b/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
@@ -1,9 +1,11 @@
 ---
 lab:
-    title: 'Exercise - Create class definitions and instantiate objects'
-    description: 'Learn how to create class definitions that include fields and constructors, and how to use the "new" operator to instantiate objects that expose encapsulated field data.'
+  title: Exercise - Create class definitions and instantiate objects
+  description: Learn how to create class definitions that include fields and constructors, and how to use the "new" operator to instantiate objects that expose encapsulated field data.
+  duration: 25 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Create class definitions and instantiate objects
 

--- a/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
+++ b/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
@@ -3,7 +3,7 @@ lab:
   title: Exercise - Update a class with properties and methods
   description: Learn how to implement class properties using property accessors and access modifiers, and how to implement methods by adding methods to a class and by developing extension methods for existing classes.
   duration: 35 minutes
-  level: 100
+  level: 200
   islab: true
 ---
 

--- a/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
+++ b/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
@@ -1,9 +1,11 @@
 ---
 lab:
-    title: 'Exercise - Update a class with properties and methods'
-    description: 'Learn how to implement class properties using property accessors and access modifiers, and how to implement methods by adding methods to a class and by developing extension methods for existing classes.'
+  title: Exercise - Update a class with properties and methods
+  description: Learn how to implement class properties using property accessors and access modifiers, and how to implement methods by adding methods to a class and by developing extension methods for existing classes.
+  duration: 35 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Update a class with properties and methods
 

--- a/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
+++ b/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
@@ -5,6 +5,9 @@ lab:
   duration: 35 minutes
   level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Update a class with properties and methods

--- a/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
+++ b/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Manage class implementations
   description: Learn how to improve code quality by creating static and partial classes, using optional parameters in constructors, and by implementing copy constructors and object initializers in your applications.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Manage class implementations

--- a/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
+++ b/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
@@ -1,9 +1,11 @@
 ---
 lab:
-    title: 'Exercise - Manage class implementations'
-    description: 'Learn how to improve code quality by creating static and partial classes, using optional parameters in constructors, and by implementing copy constructors and object initializers in your applications.'
+  title: Exercise - Manage class implementations
+  description: Learn how to improve code quality by creating static and partial classes, using optional parameters in constructors, and by implementing copy constructors and object initializers in your applications.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Manage class implementations
 

--- a/Instructions/Labs/l2p2-lp2-m1-exercise-implement-interfaces-project.md
+++ b/Instructions/Labs/l2p2-lp2-m1-exercise-implement-interfaces-project.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement Interfaces in a Project
   description: Define and implement interfaces in C# to enforce consistent behavior across multiple classes, including explicit interface implementations.
   duration: 20 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement Interfaces in a Project

--- a/Instructions/Labs/l2p2-lp2-m1-exercise-implement-interfaces-project.md
+++ b/Instructions/Labs/l2p2-lp2-m1-exercise-implement-interfaces-project.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement Interfaces in a Project'
-    description: 'Define and implement interfaces in C# to enforce consistent behavior across multiple classes, including explicit interface implementations.'
+  title: Exercise - Implement Interfaces in a Project
+  description: Define and implement interfaces in C# to enforce consistent behavior across multiple classes, including explicit interface implementations.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement Interfaces in a Project

--- a/Instructions/Labs/l2p2-lp2-m2-exercise-decouple-code-with-interfaces.md
+++ b/Instructions/Labs/l2p2-lp2-m2-exercise-decouple-code-with-interfaces.md
@@ -5,6 +5,9 @@ lab:
   duration: 25 minutes
   level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Decouple code using Interfaces

--- a/Instructions/Labs/l2p2-lp2-m2-exercise-decouple-code-with-interfaces.md
+++ b/Instructions/Labs/l2p2-lp2-m2-exercise-decouple-code-with-interfaces.md
@@ -1,8 +1,11 @@
----  
-lab:  
-    title: 'Exercise - Decouple code using Interfaces'  
-    description: 'Create flexible and maintainable code by refactoring tightly coupled code to use interfaces in C#.'  
----  
+---
+lab:
+  title: Exercise - Decouple code using Interfaces
+  description: Create flexible and maintainable code by refactoring tightly coupled code to use interfaces in C#.
+  duration: 25 minutes
+  level: 200
+  islab: true
+---
 
 # Decouple code using Interfaces
 

--- a/Instructions/Labs/l2p2-lp2-m3-exercise-create-flexible-code-with-interfaces.md
+++ b/Instructions/Labs/l2p2-lp2-m3-exercise-create-flexible-code-with-interfaces.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Create Flexible Code Using Interfaces
   description: Create flexible and maintainable code by refactoring tightly coupled code to use interfaces in C#.
   duration: 25 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Create Flexible Code Using Interfaces

--- a/Instructions/Labs/l2p2-lp2-m3-exercise-create-flexible-code-with-interfaces.md
+++ b/Instructions/Labs/l2p2-lp2-m3-exercise-create-flexible-code-with-interfaces.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Create Flexible Code Using Interfaces'
-    description: 'Create flexible and maintainable code by refactoring tightly coupled code to use interfaces in C#.'
+  title: Exercise - Create Flexible Code Using Interfaces
+  description: Create flexible and maintainable code by refactoring tightly coupled code to use interfaces in C#.
+  duration: 25 minutes
+  level: 100
+  islab: true
 ---
 
 # Create Flexible Code Using Interfaces

--- a/Instructions/Labs/l2p2-lp3-m1-exercise-implement-base-derived-classes.md
+++ b/Instructions/Labs/l2p2-lp3-m1-exercise-implement-base-derived-classes.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement base and derived classes
   description: Learn how to create a class hierarchy that implements base and derived classes. Explore using the abstract, virtual, sealed, new, and override keywords to extend base class behavior in derived classes, and how to access base class members from within a derived class using the base keyword.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement base and derived classes

--- a/Instructions/Labs/l2p2-lp3-m1-exercise-implement-base-derived-classes.md
+++ b/Instructions/Labs/l2p2-lp3-m1-exercise-implement-base-derived-classes.md
@@ -1,9 +1,11 @@
 ---
 lab:
-    title: 'Exercise - Implement base and derived classes'
-    description: 'Learn how to create a class hierarchy that implements base and derived classes. Explore using the abstract, virtual, sealed, new, and override keywords to extend base class behavior in derived classes, and how to access base class members from within a derived class using the base keyword.'
+  title: Exercise - Implement base and derived classes
+  description: Learn how to create a class hierarchy that implements base and derived classes. Explore using the abstract, virtual, sealed, new, and override keywords to extend base class behavior in derived classes, and how to access base class members from within a derived class using the base keyword.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Implement base and derived classes
 

--- a/Instructions/Labs/l2p2-lp3-m2-exercise-implement-polymorphism-csharp.md
+++ b/Instructions/Labs/l2p2-lp3-m2-exercise-implement-polymorphism-csharp.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement polymorphism in a C# app'
-    description: 'Learn the principles of polymorphism and how to implement polymorphic behavior in C# apps using interface-based and inheritance-based approaches.'
+  title: Exercise - Implement polymorphism in a C# app
+  description: Learn the principles of polymorphism and how to implement polymorphic behavior in C# apps using interface-based and inheritance-based approaches.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement polymorphism in a C# app

--- a/Instructions/Labs/l2p2-lp3-m2-exercise-implement-polymorphism-csharp.md
+++ b/Instructions/Labs/l2p2-lp3-m2-exercise-implement-polymorphism-csharp.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement polymorphism in a C# app
   description: Learn the principles of polymorphism and how to implement polymorphic behavior in C# apps using interface-based and inheritance-based approaches.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement polymorphism in a C# app

--- a/Instructions/Labs/l2p2-lp4-m1-exercise-impliment-basic-date-time.md
+++ b/Instructions/Labs/l2p2-lp4-m1-exercise-impliment-basic-date-time.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement Basic Date and Time Operations
   description: Learn how to create and manipulate date and time values in C#. Explore using DateTime, DateOnly, TimeOnly, and TimeZoneInfo classes to perform various date and time operations.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement Basic Date and Time Operations

--- a/Instructions/Labs/l2p2-lp4-m1-exercise-impliment-basic-date-time.md
+++ b/Instructions/Labs/l2p2-lp4-m1-exercise-impliment-basic-date-time.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement Basic Date and Time Operations'
-    description: 'Learn how to create and manipulate date and time values in C#. Explore using DateTime, DateOnly, TimeOnly, and TimeZoneInfo classes to perform various date and time operations.'
+  title: Exercise - Implement Basic Date and Time Operations
+  description: Learn how to create and manipulate date and time values in C#. Explore using DateTime, DateOnly, TimeOnly, and TimeZoneInfo classes to perform various date and time operations.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement Basic Date and Time Operations

--- a/Instructions/Labs/l2p2-lp4-m2-exercise-implement-collection-types.md
+++ b/Instructions/Labs/l2p2-lp4-m2-exercise-implement-collection-types.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement Collection Types
   description: Learn how to implement and use collection types in C#. Explore using List, Dictionary, HashSet, and other collection types to manage data effectively.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement Collection Types

--- a/Instructions/Labs/l2p2-lp4-m2-exercise-implement-collection-types.md
+++ b/Instructions/Labs/l2p2-lp4-m2-exercise-implement-collection-types.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement Collection Types'
-    description: 'Learn how to implement and use collection types in C#. Explore using List, Dictionary, HashSet, and other collection types to manage data effectively.'
+  title: Exercise - Implement Collection Types
+  description: Learn how to implement and use collection types in C#. Explore using List, Dictionary, HashSet, and other collection types to manage data effectively.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement Collection Types

--- a/Instructions/Labs/l2p2-lp4-m3-exercise-implement-enum-struct-record.md
+++ b/Instructions/Labs/l2p2-lp4-m3-exercise-implement-enum-struct-record.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement Enum, Struct, and Record in a Banking Application
   description: Learn how to define and implement enums, structs, and records in C#. Explore their use in a banking application to manage accounts, transactions, and customers.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement Enum, Struct, and Record in a Banking Application

--- a/Instructions/Labs/l2p2-lp4-m3-exercise-implement-enum-struct-record.md
+++ b/Instructions/Labs/l2p2-lp4-m3-exercise-implement-enum-struct-record.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement Enum, Struct, and Record in a Banking Application'
-    description: 'Learn how to define and implement enums, structs, and records in C#. Explore their use in a banking application to manage accounts, transactions, and customers.'
+  title: Exercise - Implement Enum, Struct, and Record in a Banking Application
+  description: Learn how to define and implement enums, structs, and records in C#. Explore their use in a banking application to manage accounts, transactions, and customers.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement Enum, Struct, and Record in a Banking Application

--- a/Instructions/Labs/l2p2-lp4-m4-exercise-implement-generic-anonymous-types.md
+++ b/Instructions/Labs/l2p2-lp4-m4-exercise-implement-generic-anonymous-types.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement Generics and Anonymous Types in a Banking Application'
-    description: 'Learn how to implement generics, advanced generics, and anonymous types in C#. Explore their use in a banking application to manage accounts, transactions, and customers.'
+  title: Exercise - Implement Generics and Anonymous Types in a Banking Application
+  description: Learn how to implement generics, advanced generics, and anonymous types in C#. Explore their use in a banking application to manage accounts, transactions, and customers.
+  duration: 25 minutes
+  level: 200
+  islab: true
 ---
 
 # Implement Generics and Anonymous Types in a Banking Application

--- a/Instructions/Labs/l2p2-lp4-m4-exercise-implement-generic-anonymous-types.md
+++ b/Instructions/Labs/l2p2-lp4-m4-exercise-implement-generic-anonymous-types.md
@@ -5,6 +5,9 @@ lab:
   duration: 25 minutes
   level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement Generics and Anonymous Types in a Banking Application

--- a/Instructions/Labs/l2p2-lp5-m1-exercise-implement-create-manage-text-files.md
+++ b/Instructions/Labs/l2p2-lp5-m1-exercise-implement-create-manage-text-files.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Create and manage text files'
-    description: 'Learn how to create and enumerate directories and files by using the Directory and Path classes, how to read, write, and manage text files by using the File class, how to read and write comma-separated value files by using StreamReader, StreamWriter, and FileStream classes, and how to read and write binary data files by using BinaryReader and BinaryWriter classes.'
+  title: Exercise - Create and manage text files
+  description: Learn how to create and enumerate directories and files by using the Directory and Path classes, how to read, write, and manage text files by using the File class, how to read and write comma-separated value files by using StreamReader, StreamWriter, and FileStream classes, and how to read and write binary data files by using BinaryReader and BinaryWriter classes.
+  duration: 30 minutes
+  level: 100
+  islab: true
 ---
 
 # Create and manage text files

--- a/Instructions/Labs/l2p2-lp5-m1-exercise-implement-create-manage-text-files.md
+++ b/Instructions/Labs/l2p2-lp5-m1-exercise-implement-create-manage-text-files.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Create and manage text files
   description: Learn how to create and enumerate directories and files by using the Directory and Path classes, how to read, write, and manage text files by using the File class, how to read and write comma-separated value files by using StreamReader, StreamWriter, and FileStream classes, and how to read and write binary data files by using BinaryReader and BinaryWriter classes.
   duration: 30 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Create and manage text files

--- a/Instructions/Labs/l2p2-lp5-m2-exercise-serialize-deserialize-json-files.md
+++ b/Instructions/Labs/l2p2-lp5-m2-exercise-serialize-deserialize-json-files.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Serialize and deserialize JSON files'
-    description: 'Learn how serialize and deserialize JSON using JsonSerializer methods, how to use JsonSerializerOptions to customize serialization and deserialization, and how to use Data Transfer Objects to implement serialization and deserialization when objects cannot be serialized directly.'
+  title: Exercise - Serialize and deserialize JSON files
+  description: Learn how serialize and deserialize JSON using JsonSerializer methods, how to use JsonSerializerOptions to customize serialization and deserialization, and how to use Data Transfer Objects to implement serialization and deserialization when objects cannot be serialized directly.
+  duration: 30 minutes
+  level: 200
+  islab: true
 ---
 
 # Serialize and deserialize JSON files

--- a/Instructions/Labs/l2p2-lp5-m2-exercise-serialize-deserialize-json-files.md
+++ b/Instructions/Labs/l2p2-lp5-m2-exercise-serialize-deserialize-json-files.md
@@ -5,6 +5,9 @@ lab:
   duration: 30 minutes
   level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Serialize and deserialize JSON files

--- a/Instructions/Labs/l2p2-lp5-m3-exercise-implement-async-tasks.md
+++ b/Instructions/Labs/l2p2-lp5-m3-exercise-implement-async-tasks.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement tasks asynchronously and in parallel'
-    description: 'Learn how to improve app responsiveness by converting synchronous methods into asynchronous tasks, and how to reduce performance bottlenecks in your apps by running asynchronous tasks in parallel.'
+  title: Exercise - Implement tasks asynchronously and in parallel
+  description: Learn how to improve app responsiveness by converting synchronous methods into asynchronous tasks, and how to reduce performance bottlenecks in your apps by running asynchronous tasks in parallel.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement tasks asynchronously and in parallel

--- a/Instructions/Labs/l2p2-lp5-m3-exercise-implement-async-tasks.md
+++ b/Instructions/Labs/l2p2-lp5-m3-exercise-implement-async-tasks.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement tasks asynchronously and in parallel
   description: Learn how to improve app responsiveness by converting synchronous methods into asynchronous tasks, and how to reduce performance bottlenecks in your apps by running asynchronous tasks in parallel.
   duration: 20 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement tasks asynchronously and in parallel

--- a/Instructions/Labs/l2p2-lp6-m1-exercise-implement-delegates.md
+++ b/Instructions/Labs/l2p2-lp6-m1-exercise-implement-delegates.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise - Implement delegates in a C# app'
-    description: 'Learn how to declare, instantiate, and invoke delegates for scenarios that require dynamic method invocation. Learn how to implement callback and sorting scenarios using custom delegates, and then replace the custom delegates with strongly typed delegates that reduce code complexity while providing the same functionality.'
+  title: Exercise - Implement delegates in a C# app
+  description: Learn how to declare, instantiate, and invoke delegates for scenarios that require dynamic method invocation. Learn how to implement callback and sorting scenarios using custom delegates, and then replace the custom delegates with strongly typed delegates that reduce code complexity while providing the same functionality.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement delegates in a C# app

--- a/Instructions/Labs/l2p2-lp6-m1-exercise-implement-delegates.md
+++ b/Instructions/Labs/l2p2-lp6-m1-exercise-implement-delegates.md
@@ -3,8 +3,11 @@ lab:
   title: Exercise - Implement delegates in a C# app
   description: Learn how to declare, instantiate, and invoke delegates for scenarios that require dynamic method invocation. Learn how to implement callback and sorting scenarios using custom delegates, and then replace the custom delegates with strongly typed delegates that reduce code complexity while providing the same functionality.
   duration: 20 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement delegates in a C# app

--- a/Instructions/Labs/l2p2-lp6-m2-exercise-implement-events.md
+++ b/Instructions/Labs/l2p2-lp6-m2-exercise-implement-events.md
@@ -3,8 +3,11 @@ lab:
   title: 'Exercise: Implement events in C#'
   description: Practice creating, subscribing to, and raising events in C# using delegates and custom event data classes.
   duration: 25 minutes
-  level: 100
+  level: 200
   islab: true
+  primarytopics:
+    - C# (.NET)
+    - Visual Studio Code
 ---
 
 # Implement events in C#

--- a/Instructions/Labs/l2p2-lp6-m2-exercise-implement-events.md
+++ b/Instructions/Labs/l2p2-lp6-m2-exercise-implement-events.md
@@ -1,7 +1,10 @@
 ---
 lab:
-    title: 'Exercise: Implement events in C#'
-    description: 'Practice creating, subscribing to, and raising events in C# using delegates and custom event data classes.'
+  title: 'Exercise: Implement events in C#'
+  description: Practice creating, subscribing to, and raising events in C# using delegates and custom event data classes.
+  duration: 25 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement events in C#


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 17

- `Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp2-m1-exercise-implement-interfaces-project.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp2-m2-exercise-decouple-code-with-interfaces.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp2-m3-exercise-create-flexible-code-with-interfaces.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp3-m1-exercise-implement-base-derived-classes.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp3-m2-exercise-implement-polymorphism-csharp.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp4-m1-exercise-impliment-basic-date-time.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp4-m2-exercise-implement-collection-types.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp4-m3-exercise-implement-enum-struct-record.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp4-m4-exercise-implement-generic-anonymous-types.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp5-m1-exercise-implement-create-manage-text-files.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp5-m2-exercise-serialize-deserialize-json-files.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp5-m3-exercise-implement-async-tasks.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp6-m1-exercise-implement-delegates.md` (duration,level,islab)
- `Instructions/Labs/l2p2-lp6-m2-exercise-implement-events.md` (duration,level,islab)
